### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/automerge_dependencies.yml
+++ b/.github/workflows/automerge_dependencies.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   auto-merge:


### PR DESCRIPTION
Potential fix for [https://github.com/iyaki/daily-knowledge/security/code-scanning/2](https://github.com/iyaki/daily-knowledge/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (auto-merging dependencies), the `contents: read` permission is sufficient for most operations. If the `ahmadnassri/action-dependabot-auto-merge@v2` action requires additional permissions, they should be explicitly added.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`auto-merge`) to limit permissions to that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
